### PR TITLE
fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,12 @@ language: node_js
 node_js:
 - "0.10"
 - "4.1.2"
- 
-before_install:
+addons:
+  firefox: "41.0.2"
+before_script:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
-- "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
- 
-before_script:
-- npm install jpm -g
-- rm -r node_modules/addon-pathfinder/test
-- cd ..
-- url="http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-36.0a1.en-US.linux-x86_64.tar.bz2"
-- wget -O firefox.tar.bz2 "$url"
-- bzip2 -cd firefox.tar.bz2 | tar xvf -
-- cd $TRAVIS_BUILD_DIR
- 
 script:
-- export JPM_FIREFOX_BINARY=$TRAVIS_BUILD_DIR/../firefox/firefox
+- npm install
 - jpm test -v
 


### PR DESCRIPTION
This was pointing to a firefox tarball that didn't exist. We don't need to specify the exact location of FF because travis can find it.

I've modeled this after the travis.yml here: https://github.com/nikolas/LibreJS/blob/master/.travis.yml