### PR TITLE
Make travis actually work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ node_js:
 - "0.10"
 - "4.1.2"
 addons:
-  firefox: "41.0.2"
+  firefox: latest
+env:
+  global:
+  - DISPLAY=:99.0
+  - JPM_FIREFOX_BINARY=/usr/local/bin/firefox
+before_install:
+- sh -e /etc/init.d/xvfb start
 before_script:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
+- npm install -g jpm
 script:
-- npm install jpm
-- npm install
 - jpm test -v


### PR DESCRIPTION
This makes travis actually run unit tests and always uses the latest Firefox release for tests.
See https://travis-ci.org/freaktechnik/menuitem/builds/87488935 for what happens without this patch. And https://travis-ci.org/freaktechnik/menuitem/builds/87489704 with this patch (which should be the same as the build for this pr).